### PR TITLE
Invitations

### DIFF
--- a/app/(app)/seasonSettings.jsx
+++ b/app/(app)/seasonSettings.jsx
@@ -200,7 +200,7 @@ export default function SeasonSettings() {
       const invitations = userDoc.data().seasonInvitations || [];
 
       if (invitations.some(invite => invite.ownerUserID === userID && invite.seasonID === seasonID)) {
-        
+        setAddViewerModalVisible(false)
         Alert.alert("Request already sent", "Request to join this season already sent to the user, please wait for user to accept or decline before trying again.");
         setLoading(false);
         return;

--- a/app/(app)/seasonSettings.jsx
+++ b/app/(app)/seasonSettings.jsx
@@ -17,7 +17,6 @@ import { Menu, MenuProvider, MenuOptions, MenuOption, MenuTrigger } from 'react-
 export default function SeasonSettings() {
   const router = useRouter();
   const { seasonID, user, setActiveSeason } = useAuth();
-  const userID = user?.userID; // Ensure the correct property is accessed
   const [seasonData, setSeasonData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [playerStats, setPlayerStats] = useState([]);
@@ -80,10 +79,10 @@ export default function SeasonSettings() {
       setLoading(false);
     };
 
-    if (seasonID && userID) {
+    if (seasonID && user) {
       fetchSeasonData();
     }
-  }, [seasonID, userID]);
+  }, [seasonID, user]);
 
   useEffect(() => {
     const fetchPlayerStats = async () => {
@@ -107,10 +106,10 @@ export default function SeasonSettings() {
       setLoading(false);
     };
 
-    if (seasonID && userID) {
+    if (seasonID && user) {
       fetchPlayerStats();
     }
-  }, [seasonID, userID]);
+  }, [seasonID, user]);
 
   const addOwner = async () => {
     setLoading(true);
@@ -290,6 +289,8 @@ export default function SeasonSettings() {
     </View>
   );
 
+  const userID = user?.userID;
+
   const isOwner = userID === seasonData?.access?.owner;
   const isEditor = seasonData?.access?.editors?.includes(userID);
   const isViewer = seasonData?.access?.viewers?.includes(userID);
@@ -423,7 +424,7 @@ export default function SeasonSettings() {
                 numColumns={3}
                 columnWrapperStyle={styles.columnWrapper}
                 ListFooterComponent={
-                  (isOwner || isEditor) && (
+                  (isOwner) && (
                     <TouchableOpacity style={styles.addPlayerButton} onPress={() => setAddPlayerModalVisible(true)}>
                       <Text style={styles.buttonText}>Add Player</Text>
                     </TouchableOpacity>

--- a/app/(app)/seasonSettings.jsx
+++ b/app/(app)/seasonSettings.jsx
@@ -341,7 +341,7 @@ export default function SeasonSettings() {
                     />
                   </MenuTrigger>
                   <MenuOptions>
-                    <MenuOption onSelect={() => {}} text="Owner tooltip text" />
+                    <MenuOption onSelect={() => {}} text="The owner has full permissions for a season, such as statting, viewing stats, and deleting the season." />
                   </MenuOptions>
                 </Menu>
               </View>
@@ -363,7 +363,7 @@ export default function SeasonSettings() {
                     />
                   </MenuTrigger>
                   <MenuOptions>
-                    <MenuOption onSelect={() => {}} text="Editors tooltip text" />
+                    <MenuOption onSelect={() => {}} text="Editors have full permissions for a season, with the exception that they cannot delete a season. They can stat games, view stats, and perform any other actions that an owner can take." />
                   </MenuOptions>
                 </Menu>
               </View>
@@ -388,7 +388,7 @@ export default function SeasonSettings() {
                     />
                   </MenuTrigger>
                   <MenuOptions>
-                    <MenuOption onSelect={() => {}} text="Viewers tooltip text" />
+                    <MenuOption onSelect={() => {}} text="Viewers can only view various player and season stats. Viewers cannot add any stats or delete a season." />
                   </MenuOptions>
                 </Menu>
               </View>

--- a/app/(app)/seasonSettings.jsx
+++ b/app/(app)/seasonSettings.jsx
@@ -295,10 +295,6 @@ export default function SeasonSettings() {
   const isEditor = seasonData?.access?.editors?.includes(userID);
   const isViewer = seasonData?.access?.viewers?.includes(userID);
 
-  console.log("User ID:", userID);
-  console.log("Owner:", seasonData?.access?.owner);
-  console.log("Editors:", seasonData?.access?.editors);
-  console.log("Viewers:", seasonData?.access?.viewers);
 
   return (
     <SafeView style={styles.container}>
@@ -352,7 +348,7 @@ export default function SeasonSettings() {
                     />
                   </MenuTrigger>
                   <MenuOptions>
-                    <MenuOption onSelect={() => {}} text="The owner has full permissions for a season, such as statting, viewing stats, and deleting the season." />
+                    <MenuOption onSelect={() => {}} text="The owner has full permissions for a season, such as statting, viewing stats, adding new editors/viewers, and deleting the season." />
                   </MenuOptions>
                 </Menu>
               </View>
@@ -374,7 +370,7 @@ export default function SeasonSettings() {
                     />
                   </MenuTrigger>
                   <MenuOptions>
-                    <MenuOption onSelect={() => {}} text="Editors have full permissions for a season, with the exception that they cannot delete a season. They can stat games, view stats, and perform any other actions that an owner can take." />
+                    <MenuOption onSelect={() => {}} text="Editors have full permissions for a season, with the exception that they cannot delete a season or add new editors or viewers. They can stat games, view stats, and perform any other actions that an owner can take." />
                   </MenuOptions>
                 </Menu>
               </View>
@@ -401,7 +397,7 @@ export default function SeasonSettings() {
                     />
                   </MenuTrigger>
                   <MenuOptions>
-                    <MenuOption onSelect={() => {}} text="Viewers can only view various player and season stats. Viewers cannot add any stats or delete a season." />
+                    <MenuOption onSelect={() => {}} text="Viewers can only view various player and season stats. Viewers cannot add any stats, delete a season, or add new editors or viewers" />
                   </MenuOptions>
                 </Menu>
               </View>


### PR DESCRIPTION
Still have to polish a few things, but invitation feature is nearly there!

- Added roles for viewer and editor
- Add tooltips so users can distinguish between owner, viewer, editor (only owners can add new editors and viewers to a season)
- Add UI to add season page where users can accept or decline season invitations
- Add conditional rendering that checks to see the role of the current user and renders buttons accordingly -> for example, no delete season button will be rendered for viewers or editors
- Add ability for viewer or editor to remove season from their account (but not owner's account)
- Add various checks upon attempting to send an invitation to ensure proper functionality:

1. Checks to see if that account is already a viewer or editor of that season -> if so, invitation is not sent and pop-up explains how to change roles
2. If that account already has a request from this season ID in their inbox, request won't be sent. (To prevent spamming)>

Still have to add conditional rendering of the season home for different roles, and flesh out the delete season functionality, but should be done after that!