### PR TITLE
Settings improvements

### DIFF
--- a/app/(app)/addSeason.jsx
+++ b/app/(app)/addSeason.jsx
@@ -62,7 +62,7 @@ export default function AddSeason() {
   //Keeps track of current team size(updates when the user hits add or remove buttons)
   var [teamSize, setTeamSize] = useState(8);
 
-  //players var, uploads to the db once the user hits confrim
+  //players var, uploads to the db once the user hits confirm
   var [players, setPlayers] = useState([
     {
       playerName: "",
@@ -349,7 +349,7 @@ export default function AddSeason() {
   useEffect(() => {
     const fetchInvitations = async () => {
       try {
-        setIsLoading(true); // Show loading when opening modal
+        setIsLoading(true); // Show loading when fetching invitations
         const userDoc = await firestore().collection("users").doc(user.userID).get();
         if (userDoc.exists) {
           const data = userDoc.data();
@@ -362,10 +362,10 @@ export default function AddSeason() {
       }
     };
 
-    if (user && invitationModalVisible) {
-      fetchInvitations();
+    if (user) {
+      fetchInvitations(); // Fetch invitations immediately on load
     }
-  }, [user, invitationModalVisible]);
+  }, [user]);
 
   //handles when a user updates a specific player name
   function handlePlayerNameUpdate(ID, value) {
@@ -526,7 +526,7 @@ export default function AddSeason() {
         }),
       });
 
-    //Create new season in "seasons" collcetion
+    //Create new season in "seasons" collection
     firestore()
       .collection("seasons")
       .doc(newID)
@@ -636,7 +636,8 @@ export default function AddSeason() {
       setSeasonInvitations(seasonInvitations.filter((i) => i !== invitation));
       Alert.alert(
         "Success",
-        `You are now a ${invitation.role} for ${invitation.teamName} ${invitation.teamYear}!`
+        `You are now a ${invitation.role} for ${invitation.teamName} ${invitation.teamYear}!`,
+        [{ text: "Ok", onPress: () => router.push("seasons") }] // Redirect on success
       );
     } catch (error) {
       console.error(`Failed to accept ${invitation.role} invitation:`, error);

--- a/app/(app)/addSeason.jsx
+++ b/app/(app)/addSeason.jsx
@@ -671,7 +671,8 @@ export default function AddSeason() {
     } catch (error) {
       console.error("Failed to fetch latest invitations:", error);
     } finally {
-      setIsRefreshing(false);
+      setTimeout(() => setIsRefreshing(false), 5000); // Disable the button for 5 seconds
+     
     }
   };
 

--- a/app/(app)/seasonSettings.jsx
+++ b/app/(app)/seasonSettings.jsx
@@ -654,7 +654,7 @@ export default function SeasonSettings() {
         onRequestClose={() => setModalVisible(false)}
       >
         <View style={styles.modalView}>
-          <Text style={styles.modalText}>Enter Owner's Email</Text>
+          <Text style={styles.modalText}>Enter Editor's Email</Text>
           <TextInput
             style={styles.input}
             placeholder="Email"


### PR DESCRIPTION

**Add Season Screen**
- Add refresh icon to season invitation modal to allow users to see if they have any new invites
- Add filler text when no invites are present
- Users are now re-routed to seasons page after they accept an invite

**Season Settings Screen** 
- Fixed issue with rendering where screen would render in chunks (because of firebase calls). Screen now properly shows loading indicator until ALL firebase calls are done
- Fixed various bugs with editors / viewers not properly getting removed from seasons, and also bugs where they would remove the season from account but it would still show
- Added delete season functionality, which deletes season from the owner, as well as all viewers and editors who previously had access to season 

I fixed a few edge cases I could think of, and did lots of real time testing with 2 tablets, but there's definitely still some edge cases that could cause a crash, especially when deleting a season. Users won't be deleting seasons very often or at all tho, so this shouldn't matter too much. 